### PR TITLE
Default to '[no journal info from DOI]' when journal info is absent

### DIFF
--- a/coldfront/core/publication/views.py
+++ b/coldfront/core/publication/views.py
@@ -117,12 +117,20 @@ class PublicationSearchResultView(LoginRequiredMixin, UserPassesTestMixin, Templ
             '{\\textemdash}', '-').replace('{\\textasciigrave}', ' ').replace('{\\textdaggerdbl}', ' ').replace('{\\textdagger}', ' ')
         title = as_text(bib_json['title']).replace('{\\textquotesingle}', "'").replace('{\\textendash}', '-').replace(
             '{\\textemdash}', '-').replace('{\\textasciigrave}', ' ').replace('{\\textdaggerdbl}', ' ').replace('{\\textdagger}', ' ')
-        journal = as_text(bib_json['journal']).replace('{\\textquotesingle}', "'").replace('{\\textendash}', '-').replace(
-            '{\\textemdash}', '-').replace('{\\textasciigrave}', ' ').replace('{\\textdaggerdbl}', ' ').replace('{\\textdagger}', ' ')
 
         author = re.sub("{|}", "", author)
         title = re.sub("{|}", "", title)
-        journal = re.sub("{|}", "", journal)
+
+        # not all bibtex entries will have a journal field
+        if 'journal' in bib_json:
+            journal = as_text(bib_json['journal']).replace('{\\textquotesingle}', "'").replace('{\\textendash}', '-').replace(
+                '{\\textemdash}', '-').replace('{\\textasciigrave}', ' ').replace('{\\textdaggerdbl}', ' ').replace('{\\textdagger}', ' ')
+            journal = re.sub("{|}", "", journal)
+        else:
+            # fallback: clearly indicate that data was absent
+            source_name = matching_source_obj.name
+            journal = '[no journal info from {}]'.format(source_name.upper())
+
         pub_dict = {}
         pub_dict['author'] = author
         pub_dict['year'] = year


### PR DESCRIPTION
Single commit, commit message body:
```
'DOI' is replaced by 'ADSABS' for that source

Note that this string is displayed directly to the user where the
journal would normally be displayed. Thus, it was selected to stand out
visually (hence square brackets '[]') and be clearly different than a
real journal name.
```

The testing for this function is starting to get ugly, even for me. I've got an itch to refactor it, but in lieu of doing too much here, I just added a few comments to (hopefully) make it more readable.

As for implementation, I decided to use a format string to address the case where the source is 'ADSABS' (looks up via `http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode={unique_id}&data_type=BIBTEX'`) instead of doi.
ADSABS is not part of the default publication sources, and thus I haven't done any testing on it in this change nor prior. However, the function I edited does do a lookup to that, if the source is defined (with name `adsabs`) and the doi request / data parsing thereafter raises an exception.
Using a format string here was a simple way to accommodate that case w/o much effort.